### PR TITLE
Xapi 1385

### DIFF
--- a/internal/features/replication/env.go
+++ b/internal/features/replication/env.go
@@ -35,3 +35,19 @@ func initializeEnvironment() (replicator.Replicator, *sql.DB, error) {
 	rep, err := factory.New(locker, httpReplicator, oraDB.DB)
 	return rep, oraDB.DB, err
 }
+
+func getMoreReplicator(db *sql.DB)(replicator.Replicator) {
+	ts := httptest.NewServer(http.HandlerFunc(feedmock.GetMoreFeedHandler))
+	url, _ := url.Parse(ts.URL)
+
+	log.Infof("test server endpoint is %s", url.Host)
+	httpReplicator := replicator.NewHttpFeedReader(url.Host, "http", "", nil)
+
+	locker := new(replicator.TableLocker)
+
+	factory := replicator.OraEventStoreReplicatorFactory{}
+
+	rep, _ := factory.New(locker, httpReplicator, db)
+	return rep
+}
+

--- a/internal/features/replication/replication.feature
+++ b/internal/features/replication/replication.feature
@@ -12,4 +12,4 @@ Feature: Feed replication
     When the latest aggregate reference is not in the source
     And I replicate
     Then I pick up the new events anyway
-    And the non-existant aggregate is removed from the database
+    And the non-existent aggregate is removed from the database

--- a/internal/features/replication/replication.feature
+++ b/internal/features/replication/replication.feature
@@ -4,3 +4,10 @@ Feature: Feed replication
     And an empty replication db
     When I process events
     Then the first feed page is replicated
+
+  Scenario:
+    Given a replicator
+    And new events to replicate
+    When the latest aggregate reference is not in the source
+    And I replicate
+    Then I pick up the new events anyway

--- a/internal/features/replication/replication.feature
+++ b/internal/features/replication/replication.feature
@@ -1,3 +1,4 @@
+@replication
 Feature: Feed replication
   Scenario:
     Given a replicator
@@ -11,3 +12,4 @@ Feature: Feed replication
     When the latest aggregate reference is not in the source
     And I replicate
     Then I pick up the new events anyway
+    And the non-existant aggregate is removed from the database

--- a/internal/features/replication/replication_steps.go
+++ b/internal/features/replication/replication_steps.go
@@ -95,7 +95,7 @@ func init() {
 
 	})
 
-	And(`^the non-existant aggregate is removed from the database$`, func() {
+	And(`^the non-existent aggregate is removed from the database$`, func() {
 		count := 1
 		err := db.QueryRow(`select count(*) from t_aeev_events where aggregate_id = 'foo' and version = 1`).Scan(&count)
 		if assert.Nil(T,err) {

--- a/internal/features/replication/replication_steps.go
+++ b/internal/features/replication/replication_steps.go
@@ -60,6 +60,50 @@ func init() {
 		}
 	})
 
+	And(`^new events to replicate$`, func() {
+		replicator = getMoreReplicator(db)
+	})
+
+	When(`^the latest aggregate reference is not in the source$`, func() {
+		_,err := db.Exec(`insert into t_aeev_events(aggregate_id, version, typecode) values('foo',1, 'footc')`)
+		assert.Nil(T,err)
+	})
+
+	And(`^I replicate$`, func() {
+		//Next replication run picks up second page
+		_, err := replicator.ProcessFeed()
+		assert.Nil(T, err)
+
+		//Running the replicator again picks up the most recent events
+		_, err = replicator.ProcessFeed()
+		assert.Nil(T, err)
+	})
+
+	Then(`^I pick up the new events anyway$`, func() {
+		dbEntries, err := getEntries(db)
+		var foundLatestFromMoreFeed bool
+		if assert.Nil(T,err) {
+			for _, entry := range dbEntries {
+				log.Print(entry.ID)
+				if entry.ID == "urn:esid:ad5f255c-c5f2-42cb-7f06-5be564e91fd9:1" {
+					foundLatestFromMoreFeed = true
+					break
+				}
+			}
+		}
+		assert.True(T, foundLatestFromMoreFeed)
+
+	})
+
+	And(`^the non-existant aggregate is removed from the database$`, func() {
+		count := 1
+		err := db.QueryRow(`select count(*) from t_aeev_events where aggregate_id = 'foo' and version = 1`).Scan(&count)
+		if assert.Nil(T,err) {
+			assert.Equal(T, 0, count)
+		}
+	})
+
+
 }
 
 func getEntries(db *sql.DB) ([]*atom.Entry, error) {

--- a/replicator.go
+++ b/replicator.go
@@ -70,11 +70,12 @@ type OraEventStoreReplicator struct {
 
 func formLastReplicatedEventQuery(exclusions []string) string {
 	if len(exclusions) == 0 {
-		return `select aggregate_id, version from t_aeev_events order by id desc limit 1`
+		//return `select aggregate_id, version from t_aeev_events order by id desc limit 1`
+		return `select aggregate_id, version from (select aggregate_id, version from t_aeev_events order by id desc) where rownum < 2`
 	}
 
 	//We want the last aggregate minus the ones we know do not exist
-	var query = `select aggregate_id, version from t_aeev_events where  aggregate_id not in (`
+	var query = `select aggregate_id, version from (select aggregate_id, version from t_aeev_events where  aggregate_id not in (`
 	first := true
 	for _, aggregateId := range exclusions {
 		if first == true {
@@ -87,7 +88,7 @@ func formLastReplicatedEventQuery(exclusions []string) string {
 
 	}
 
-	query = query + `) order by id desc limit 1`
+	query = query + `) order by id desc) where rownum < 2`
 
 	return query
 }

--- a/replicator.go
+++ b/replicator.go
@@ -72,11 +72,11 @@ func formLastReplicatedEventQuery() string {
 	return `select aggregate_id, version from t_aeev_events where id = (select max(id) from t_aeev_events)`
 }
 
-// If we encounter a non-existant entity as the latest in our feed, we need to remove it
+// If we encounter a non-existent entity as the latest in our feed, we need to remove it
 // from the database or we might not be able to make progress in reading later events if we
 // keep searching the feed for the entity.
-func deleteNonexistantEntity(tx *sql.Tx, aggregate_id string, version int) error {
-	log.Warnf("Deleting non-existant aggregate %s %d from database", aggregate_id, version)
+func deleteNonexistentEntity(tx *sql.Tx, aggregate_id string, version int) error {
+	log.Warnf("Deleting non-existent aggregate %s %d from database", aggregate_id, version)
 	_,err := tx.Exec(`delete from t_aepb_publish where aggregate_id = :1 and version = :2`, aggregate_id, version)
 	if err != nil {
 		return err
@@ -118,7 +118,7 @@ func lastReplicatedEvent(feedReader FeedReader, tx *sql.Tx) (string, int, error)
 		}
 
 		//If the aggregate does not exist, delete it.
-		err = deleteNonexistantEntity(tx, aggregateID, version)
+		err = deleteNonexistentEntity(tx, aggregateID, version)
 		if err != nil {
 			return "", -1, err
 		}

--- a/replicator_test.go
+++ b/replicator_test.go
@@ -475,17 +475,17 @@ func TestEventPresentWhenServerReturnsError(t *testing.T) {
 func TestFormLastEventQueryNoExclusions(t *testing.T) {
 	var exclusions []string
 	query := formLastReplicatedEventQuery(exclusions)
-	assert.Equal(t, "select aggregate_id, version from t_aeev_events order by id desc limit 1", query)
+	assert.Equal(t, "select aggregate_id, version from (select aggregate_id, version from t_aeev_events order by id desc) where rownum < 2", query)
 }
 
 func TestFormLastEventQueryWithOneExclusion(t *testing.T) {
 	var exclusions = []string{"abc123"}
 	query := formLastReplicatedEventQuery(exclusions)
-	assert.Equal(t, "select aggregate_id, version from t_aeev_events where  aggregate_id not in ( 'abc123') order by id desc limit 1", query)
+	assert.Equal(t, "select aggregate_id, version from (select aggregate_id, version from t_aeev_events where  aggregate_id not in ( 'abc123') order by id desc) where rownum < 2", query)
 }
 
 func TestFormLastEventQueryWithMultipleExclusions(t *testing.T) {
 	var exclusions = []string{"abc123", "foo123", "bar123"}
 	query := formLastReplicatedEventQuery(exclusions)
-	assert.Equal(t, "select aggregate_id, version from t_aeev_events where  aggregate_id not in ( 'abc123','foo123','bar123') order by id desc limit 1", query)
+	assert.Equal(t, "select aggregate_id, version from (select aggregate_id, version from t_aeev_events where  aggregate_id not in ( 'abc123','foo123','bar123') order by id desc) where rownum < 2", query)
 }

--- a/replicator_test.go
+++ b/replicator_test.go
@@ -386,3 +386,15 @@ func TestUniqueConstraintErrorTest(t *testing.T) {
 	errText = "Replication insert failed: ORA-00001: unique constraint (APIFPDM1AXWFDBO.AEEVPK_AGGREGATE_ID$VERSION) violated"
 	assert.True(t, isUniqueConstraintViolation(errText))
 }
+
+func TestEventPresentWhenExists(t *testing.T) {
+
+}
+
+func TestEventPresentWhenNonExistant(t *testing.T) {
+
+}
+
+func TestEventPresentWhenServerReturnsError(t *testing.T) {
+	
+}

--- a/replicator_test.go
+++ b/replicator_test.go
@@ -447,7 +447,7 @@ func TestEventPresentWhenExists(t *testing.T) {
 
 	exists, err := httpReplicator.isPresentInSource(endpoint, "i-know-this", 7)
 	if assert.Nil(t, err) {
-		assert.True(t, exists, "Expected aggregate to be flagged as non-existant")
+		assert.True(t, exists, "Expected aggregate to be flagged as non-existent")
 	}
 }
 
@@ -461,9 +461,9 @@ func TestEventPresentWhenNonExistant(t *testing.T) {
 
 	endpoint := fmt.Sprintf("http://%s/events", url.Host)
 
-	exists, err := httpReplicator.isPresentInSource(endpoint, "non-existant", 7)
+	exists, err := httpReplicator.isPresentInSource(endpoint, "non-existent", 7)
 	if assert.Nil(t, err) {
-		assert.False(t, exists, "Expected aggregate to be flagged as non-existant")
+		assert.False(t, exists, "Expected aggregate to be flagged as non-existent")
 	}
 }
 

--- a/testing/mockfeed.go
+++ b/testing/mockfeed.go
@@ -32,6 +32,42 @@ var Recent = `
     </entry>
 </feed>`
 
+
+var MoreRecent = `
+<feed
+    xmlns="http://www.w3.org/2005/Atom">
+    <title>Event store feed</title>
+    <id>recent</id>
+    <link rel="self" href="http://localhost:5000/notifications/recent"></link>
+    <link rel="related" href="http://localhost:5000/notifications/recent"></link>
+    <link rel="prev-archive" href="http://localhost:5000/notifications/9BC3EA7D-51E2-8C61-0E08-02368CD22054"></link>
+    <updated>2016-10-31T11:05:28-07:00</updated>
+    <entry>
+        <title>event</title>
+        <id>urn:esid:ad5f255c-c5f2-42cb-7f06-5be564e91fd9:1</id>
+        <link rel="self" href="http://localhost:5000/notifications/ad5f255c-c5f2-42cb-7f06-5be564e91fd9/1"></link>
+        <published>2016-10-31T11:03:06.232441-07:00</published>
+        <updated></updated>
+        <content type="TACRE">CiQ5YzVmMjU1Yy1jNWYyLTQyY2ItN2YwNi01YmU1NjRlOTFmZDkSBWZvbyA3GgViYXIgNyITYmF6ICUhZChNSVNTSU5HKSwgaQ==</content>
+    </entry>
+    <entry>
+        <title>event</title>
+        <id>urn:esid:9c5f255c-c5f2-42cb-7f06-5be564e91fd9:1</id>
+        <link rel="self" href="http://localhost:5000/notifications/9c5f255c-c5f2-42cb-7f06-5be564e91fd9/1"></link>
+        <published>2016-10-31T11:03:05.232441-07:00</published>
+        <updated></updated>
+        <content type="TACRE">CiQ5YzVmMjU1Yy1jNWYyLTQyY2ItN2YwNi01YmU1NjRlOTFmZDkSBWZvbyA3GgViYXIgNyITYmF6ICUhZChNSVNTSU5HKSwgaQ==</content>
+    </entry>
+    <entry>
+        <title>event</title>
+        <id>urn:esid:1f454e71-42f9-4d88-6979-ae643aa88cdd:1</id>
+        <link rel="self" href="http://localhost:5000/notifications/1f454e71-42f9-4d88-6979-ae643aa88cdd/1"></link>
+        <published>2016-10-31T11:03:05.224863-07:00</published>
+        <updated></updated>
+        <content type="TACRE">CiQxZjQ1NGU3MS00MmY5LTRkODgtNjk3OS1hZTY0M2FhODhjZGQSBWZvbyA1GgViYXIgNSITYmF6ICUhZChNSVNTSU5HKSwgaQ==</content>
+    </entry>
+</feed>`
+
 var SecondArchive = `
 <feed
     xmlns="http://www.w3.org/2005/Atom">
@@ -130,8 +166,50 @@ var RecentHandler = func(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(Recent))
 }
 
+var knownAggregates = []string{
+	"9c5f255c-c5f2-42cb-7f06-5be564e91fd9",
+	"1f454e71-42f9-4d88-6979-ae643aa88cdd",
+	"ad5f255c-c5f2-42cb-7f06-5be564e91fd9",
+	"9f02eae0-bf8c-46c1-7afb-9af83616b0ae",
+	"f3234d82-0cff-4221-64de-315c8ab6dbd6",
+	"3418b971-0ea8-483d-4520-9bfbc6a1d356",
+	"e44afbe7-e24f-4bdf-4fa8-9cfc46e4c496",
+	"3a56b98b-0a03-4822-44c7-93216255d857",
+	"cee18efc-0568-48f9-764c-149085ea0324",
+
+}
+
+func isKnownEvent(aggregateID string) bool {
+	for _, aggID := range knownAggregates {
+		if aggID == aggregateID {
+			return true
+		}
+	}
+
+	return false
+}
+
+func processExistanceTest(w http.ResponseWriter, path string) {
+
+	parts := strings.Split(path, "/")
+	if len(parts) == 4 {
+		if isKnownEvent(parts[2]) {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+	}
+	w.WriteHeader(http.StatusNotFound)
+}
+
 var GetFeedHandler = func(w http.ResponseWriter, r *http.Request) {
 
+	//Checking for specific event?
+	if strings.HasPrefix(r.URL.Path, "/events") {
+		processExistanceTest(w, r.URL.Path)
+		return
+	}
+
+	//Implement feed data
 	parts := strings.Split(r.URL.Path, "/")
 	feedid := parts[len(parts)-1]
 
@@ -139,6 +217,35 @@ var GetFeedHandler = func(w http.ResponseWriter, r *http.Request) {
 	switch feedid {
 	case "recent":
 		feedData = Recent
+	case "9BC3EA7D-51E2-8C61-0E08-02368CD22054":
+		feedData = SecondArchive
+	case "9AF82230-6137-4DA3-3580-80EDA74B0DE2":
+		feedData = FirstArchive
+	}
+
+	if feedData == "" {
+		http.Error(w, "", http.StatusNotFound)
+		return
+	}
+
+	w.Write([]byte(feedData))
+}
+
+var GetMoreFeedHandler = func(w http.ResponseWriter, r *http.Request) {
+
+	//Checking for specific event?
+	if strings.HasPrefix(r.URL.Path, "/events") {
+		processExistanceTest(w, r.URL.Path)
+		return
+	}
+
+	parts := strings.Split(r.URL.Path, "/")
+	feedid := parts[len(parts)-1]
+
+	var feedData string
+	switch feedid {
+	case "recent":
+		feedData = MoreRecent
 	case "9BC3EA7D-51E2-8C61-0E08-02368CD22054":
 		feedData = SecondArchive
 	case "9AF82230-6137-4DA3-3580-80EDA74B0DE2":

--- a/testing/mockfeed.go
+++ b/testing/mockfeed.go
@@ -162,9 +162,9 @@ var RetrieveEventHandler = func(w http.ResponseWriter, r *http.Request) {
 	case "non-existant":
 		statusCode = http.StatusNotFound
 	case "error-time":
-		statusCode = http.StatusOK
-	default:
 		statusCode = http.StatusInternalServerError
+	default:
+		statusCode = http.StatusOK
 	}
 
 	w.WriteHeader(statusCode)

--- a/testing/mockfeed.go
+++ b/testing/mockfeed.go
@@ -152,3 +152,20 @@ var GetFeedHandler = func(w http.ResponseWriter, r *http.Request) {
 
 	w.Write([]byte(feedData))
 }
+
+var RetrieveEventHandler = func(w http.ResponseWriter, r *http.Request) {
+	parts := strings.Split(r.URL.Path, "/")
+	aggregateId := parts[len(parts) - 2]
+
+	var statusCode int
+	switch aggregateId {
+	case "non-existant":
+		statusCode = http.StatusNotFound
+	case "error-time":
+		statusCode = http.StatusOK
+	default:
+		statusCode = http.StatusInternalServerError
+	}
+
+	w.WriteHeader(statusCode)
+}

--- a/testing/mockfeed.go
+++ b/testing/mockfeed.go
@@ -266,7 +266,7 @@ var RetrieveEventHandler = func(w http.ResponseWriter, r *http.Request) {
 
 	var statusCode int
 	switch aggregateId {
-	case "non-existant":
+	case "non-existent":
 		statusCode = http.StatusNotFound
 	case "error-time":
 		statusCode = http.StatusInternalServerError


### PR DESCRIPTION
This pull request handles the case where the latest aggregate in a replicated event store instance does not exist in the source event store. In this case the non-existent aggregate is removed from the database so the event feed can be processed start with the latest aggregate the exists in the source db.

In general the delete should be ok as our intent is to have a replicated db that can be purged and recreated from the source at anytime.