### PR TITLE
Build fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 containerbin:
+	go get github.com/gucumber/gucumber/cmd/gucumber
 	export PKG_CONFIG_PATH=$GOPATH/src/github.com/xtracdev/es-atom-replicator/pkgconfig/
 	go test
 	gucumber

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,5 @@
 containerbin:
-	go get github.com/Sirupsen/logrus
-	go get github.com/xtracdev/goes
-	go get github.com/gucumber/gucumber/cmd/gucumber
-	go get github.com/stretchr/testify/assert
-	go get github.com/armon/go-metrics
-	go get gopkg.in/DATA-DOG/go-sqlmock.v1
-	go get golang.org/x/tools/blog/atom
-	go get github.com/xtracdev/tlsconfig
 	export PKG_CONFIG_PATH=$GOPATH/src/github.com/xtracdev/es-atom-replicator/pkgconfig/
-	go get github.com/rjeczalik/pkgconfig/cmd/pkg-config
-	go get github.com/xtracdev/oraconn
-	go get github.com/aws/aws-sdk-go/...
 	go test
 	gucumber
 	GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -o replicator ./cmd/


### PR DESCRIPTION
This fix is to remove the 'go get' commands from the makefile to allow the vendored versions of the packages to be picked up by the build.

Note that the gucumber go get has been left in the build as we use the open source version for our open source projects, not our locally modified version.